### PR TITLE
Add automated contributors #70

### DIFF
--- a/source/contrib/automated_contributors.py
+++ b/source/contrib/automated_contributors.py
@@ -23,23 +23,30 @@ repositories = [
 ]
 
 unique_contributors = set()
+contributors_list = []
+
+
+for repo_name in repositories:
+    repo = g.get_repo(repo_name)
+    contributors = repo.get_contributors()
+
+    for contributor in contributors:
+        username = contributor.login
+
+        if username not in unique_contributors:
+            user = g.get_user(username)
+
+            # check if the user has a full name and if so, use it else use username
+            if user is not None and user.name is not None:
+                contributors_list.append((user.name, username))
+            else:
+                contributors_list.append((username, username))
+            unique_contributors.add(username)
+
+contributors_list.sort()
 
 with open("contributors.md", "w") as contributors_file:
-    for repo_name in repositories:
-        repo = g.get_repo(repo_name)
-        contributors = repo.get_contributors()
-
-        for contributor in contributors:
-            username = contributor.login
-
-            if username not in unique_contributors:
-                user = g.get_user(username)
-
-                # check if the user has a full name and if so, use it else use username
-                if user is not None and user.name is not None:
-                    contributors_file.write(f"- [{user.name}]({user.html_url})\n")
-                else:
-                    contributors_file.write(f"- [{username}](https://github.com/{username})\n")
-                unique_contributors.add(username)
+    for real_name, username in contributors_list:
+        contributors_file.write(f"- [{real_name}](https://github.com/{username})\n")
 
 print("Contributors have been updated in contributors.md")

--- a/source/contrib/automated_contributors.py
+++ b/source/contrib/automated_contributors.py
@@ -1,0 +1,47 @@
+from github import Github
+from github import Auth
+
+access_token = "YOUR_ACCESS_TOKEN"
+
+auth = Auth.Token(access_token)
+
+g = Github(auth=auth)
+
+repositories = [
+    "openchemistry/avogadrolibs",
+    "openchemistry/avogadroapp",
+    "openchemistry/fragments",
+    "openchemistry/molecules",
+    "openchemistry/crystals",
+    "openchemistry/avogenerators",
+    "openchemistry/avogadro-commands",
+    "openchemistry/avogadro-cclib",
+    "cryos/avogadro",
+]
+
+unique_contributors = set()
+
+with open("contributors.md", "w") as contributors_file:
+    for repo_name in repositories:
+        repo = g.get_repo(repo_name)
+        contributors = repo.get_contributors()
+
+        for contributor in contributors:
+            username = contributor.login
+            unique_contributors.add(username)
+            contributors_file.write(f"- {username}\n")
+
+sorted_contributors = sorted(unique_contributors)
+
+with open("credits.md", "r") as credits_file:
+    credits_content = credits_file.read()
+
+updated_credits_content = credits_content.replace(
+    "```{include} contributors.md```",
+    f"```{{include}} contributors.md\n\n" + "\n".join(sorted_contributors) + "\n```"
+)
+
+with open("credits.md", "w") as credits_file:
+    credits_file.write(updated_credits_content)
+
+print("Contributors have been updated in contributors.md and credits.md.")

--- a/source/contrib/contributors.md
+++ b/source/contrib/contributors.md
@@ -138,3 +138,4 @@
 - yavgech
 - yuri@FreeBSD
 - Ondřej Čertík
+- Kailin Xing

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -5,3 +5,4 @@ pydata-sphinx-theme
 sphinx-design
 sphinx-copybutton
 linkify-it-py
+PyGithub


### PR DESCRIPTION
This PR solves Issue #70 

This PR is an extension of PR #73 and preserves the commits of the previous contributor

Changes:
 - [x] Add `GITHUB_TOKEN` using environment variable
 - [x] Removed **cryos/avogadro** from repositories variable as it has been closed
 - [x] Removed the code that updates `credits.md` as it is handled by Sphinx
 - [x] Added code block to add full name of the contributor if its is not available then the username is used
 - [x] Removed the sort as it was doing nothing. 