### PR TITLE
Reorganized downloads grid

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -85,7 +85,16 @@ myst_substitutions = {
   "macurl": f"https://github.com/OpenChemistry/avogadrolibs/releases/download/{version}/Avogadro2-{version}-Darwin.dmg",
   "macarmurl": f"https://github.com/OpenChemistry/avogadrolibs/releases/download/{version}/Avogadro2-{version}-Darwin-arm64.dmg",
   "winurl": f"https://github.com/OpenChemistry/avogadrolibs/releases/download/{version}/Avogadro2-{version}-win64.exe",
-  "appurl": f"https://github.com/OpenChemistry/avogadrolibs/releases/download/{version}/Avogadro2-x86_64.AppImage"
+  "appurl": f"https://github.com/OpenChemistry/avogadrolibs/releases/download/{version}/Avogadro2-x86_64.AppImage",
+  "sourceurl": f"https://github.com/OpenChemistry/avogadrolibs/archive/refs/tags/{version}.zip",
+}
+
+myst_url_schemes = {
+    "http": None,
+    "https": None,
+    "release": f"https://github.com/OpenChemistry/avogadrolibs/releases/download/{version}/Avogadro2-{version}-" + "{{file}}",
+    "release-no-version": f"https://github.com/OpenChemistry/avogadrolibs/releases/download/{version}/Avogadro2-" + "{{file}}",
+    "source": f"https://github.com/OpenChemistry/avogadrolibs/archive/refs/tags/{version}" + "{{file}}",
 }
 
 # List of patterns, relative to source directory, that match files and

--- a/source/install/index.md
+++ b/source/install/index.md
@@ -54,15 +54,14 @@ macOS
 :text-align: center
 :shadow: none
 
-%:::{button-link} {{ 'https://github.com/OpenChemistry/avogadrolibs/releases/download/{}/Avogadro2-{}-Darwin-arm64.dmg'.format(release) }}
-:::{button-link} {{macarmurl}}
+:::{button-link} https://github.com/OpenChemistry/avogadrolibs/releases/latest/download/Avogadro2-1.99.0-Darwin-arm64.dmg
 :ref-type: myst
 :color: primary
 :outline:
 Download DMG (Apple Silicon)
 :::
 
-:::{button-link} {{macurl}}
+:::{button-link} https://github.com/OpenChemistry/avogadrolibs/releases/latest/download/Avogadro2-1.99.0-Darwin.dmg
 :color: primary
 :outline:
 Download DMG (Intel)
@@ -100,7 +99,7 @@ Windows
 :text-align: center
 :shadow: none
 
-:::{button-link} {{winurl}}
+:::{button-link} https://github.com/OpenChemistry/avogadrolibs/releases/latest/download/Avogadro2-1.99.0-win64.exe
 :color: primary
 :outline:
 Download Installer
@@ -137,7 +136,7 @@ Linux
 :text-align: center
 :shadow: none
 
-:::{button-link} {{appurl}}
+:::{button-link} https://github.com/OpenChemistry/avogadrolibs/releases/latest/download/Avogadro2-x86_64.AppImage
 :color: primary
 :outline:
 Download AppImage
@@ -217,10 +216,15 @@ Source Code
 :text-align: center
 :shadow: none
 
-:::{button-link} test
+:::{button-link} https://github.com/OpenChemistry/avogadrolibs/releases/latest/
 :color: primary
 :outline:
-Download .zip
+`avogadrolibs`
+:::
+:::{button-link} https://github.com/OpenChemistry/avogadroapp/releases/latest/
+:color: primary
+:outline:
+`avogadroapp`
 :::
 ::::
 
@@ -232,7 +236,7 @@ Download .zip
 :::{button-link} https://github.com/OpenChemistry/avogadrolibs
 :color: secondary
 :outline:
-Go to GitHub {fab}`github;fa-1x`
+Avogadro on GitHub {fab}`github;fa-1x`
 :::
 ::::
 

--- a/source/install/index.md
+++ b/source/install/index.md
@@ -8,18 +8,19 @@ If you have problems using the current release or want to use the latest feature
 
 We're open-source, so if you would like to compile Avogadro yourself from the code, you can -- see [Building Source Code](install-build) for more on how.
 
-<release:Darwin-arm64.dmg>
 
-::::::{grid} 3
+::::::{grid}
 :gutter: 0
 
 % Title row
 ::::{grid-item}
+:columns: 4 4 2 2
 % Empty
 ::::
 
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 :class-card: sd-font-weight-bold sd-bg-light sd-text-dark
@@ -28,6 +29,7 @@ Current Release ({{release}})
 
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 :class-card: sd-font-weight-bold sd-bg-light sd-text-dark
@@ -37,6 +39,7 @@ Nightly Build
 
 % Mac row
 ::::{grid-item-card}
+:columns: 4 4 2 2
 :text-align: center
 :shadow: none
 :class-card: sd-font-weight-bold sd-bg-light sd-text-dark
@@ -47,6 +50,7 @@ macOS
 
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
@@ -67,6 +71,7 @@ Download DMG (Intel)
 
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
@@ -80,6 +85,7 @@ Download Nightly Build (Intel)
 
 % Windows row
 ::::{grid-item-card}
+:columns: 4 4 2 2
 :text-align: center
 :shadow: none
 :class-card: sd-font-weight-bold sd-bg-light sd-text-dark
@@ -90,6 +96,7 @@ Windows
 
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
@@ -102,6 +109,7 @@ Download Installer
 
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
@@ -115,6 +123,7 @@ Download Nightly Build
 
 % Linux row
 ::::{grid-item-card}
+:columns: 4 4 2 2
 :text-align: center
 :shadow: none
 :class-card: sd-font-weight-bold sd-bg-light sd-text-dark
@@ -124,6 +133,7 @@ Linux
 ::::
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
@@ -148,6 +158,7 @@ Check your distro's repositories
 
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
@@ -161,6 +172,7 @@ Nightly AppImage
 
 % BSD row
 ::::{grid-item-card}
+:columns: 4 4 2 2
 :text-align: center
 :shadow: none
 :class-card: sd-font-weight-bold sd-bg-light sd-text-dark
@@ -170,6 +182,7 @@ FreeBSD
 ::::
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
@@ -181,6 +194,7 @@ FreeBSD
 ::::
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 % Empty
@@ -189,6 +203,7 @@ FreeBSD
 
 % Source code row
 ::::{grid-item-card}
+:columns: 4 4 2 2
 :text-align: center
 :shadow: none
 :class-card: sd-font-weight-bold sd-bg-light sd-text-dark
@@ -198,10 +213,11 @@ Source Code
 ::::
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
-:::{button-link} {{sourceurl}}
+:::{button-link} test
 :color: primary
 :outline:
 Download .zip
@@ -209,6 +225,7 @@ Download .zip
 ::::
 
 ::::{grid-item-card}
+:columns: 4 4 5 5
 :text-align: center
 :shadow: none
 
@@ -218,7 +235,6 @@ Download .zip
 Go to GitHub {fab}`github;fa-1x`
 :::
 ::::
-
 
 ::::::
 

--- a/source/install/index.md
+++ b/source/install/index.md
@@ -2,46 +2,176 @@
 
 # Install
 
-In addition to installing the latest release ({{release}}), there are nightly builds and anyone can build Avogadro from source code.
+Most users will want to use the current official release ({{release}}).
 
-:::{card}
+If you have problems using the current release or want to use the latest features, try out one of the **"nightly" builds** created every night from the current source code, which contains all improvements and bug fixes since the last release.
+
+We're open-source, so if you would like to compile Avogadro yourself from the code, you can – see [Building Source Code](install-build).
+
+
+::::::{grid} 3
+:gutter: 0
+
+% Title row
+::::{grid-item}
+% Empty
+::::
+
+
+::::{grid-item-card}
 :text-align: center
-:class-header: sd-font-weight-bold sd-bg-light
-{fab}`apple;fa-2x` MacOS
-^^^
-{{ '<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="' + macurl + '"><span>Download DMG</span></a>'}}
-++++
-<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_cmake/master/macOS.dmg.zip"><span>Download Nightly Build</span></a>
+:shadow: none
+:class-card: sd-font-weight-bold sd-bg-light
+Current Release ({{release}})
+::::
+
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+:class-card: sd-font-weight-bold sd-bg-light
+Nightly Build
+::::
+
+
+% Mac row
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+:class-card: sd-font-weight-bold sd-bg-light
+{fab}`apple;fa-2x` macOS
+::::
+
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+
+:::{button-link} {{macurl}}
+:color: primary
+:outline:
+Download DMG
 :::
+::::
 
-:::{card}
+
+::::{grid-item-card}
 :text-align: center
-:class-header: sd-font-weight-bold sd-bg-light
+:shadow: none
+
+:::{button-link} https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_cmake/master/macOS.dmg.zip
+:color: secondary
+:outline:
+Download Nightly Build
+:::
+::::
+
+
+% Windows row
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+:class-card: sd-font-weight-bold sd-bg-light
 {fab}`windows;fa-2x` Windows
-^^^
-{{ '<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="' + winurl + '"><span>Download Installer</span></a>'}}
-++++
-<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_cmake/master/Win64.exe.zip"><span>Download Nightly Build</span></a>
-:::
+::::
 
-:::{card}
+
+::::{grid-item-card}
 :text-align: center
-:class-header: sd-font-weight-bold sd-bg-light
+:shadow: none
+
+:::{button-link} {{winurl}}
+:color: primary
+:outline:
+Download Installer
+:::
+::::
+
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+
+:::{button-link} https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_cmake/master/Win64.exe.zip
+:color: secondary
+:outline:
+Download Nightly Build
+:::
+::::
+
+
+% Linux row
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+:class-card: sd-font-weight-bold sd-bg-light
 {fab}`linux;fa-2x` Linux
-^^^
-{{ '<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="' + appurl + '"><span>Download AppImage</span></a>'}} <a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="https://dl.flathub.org/repo/appstream/org.openchemistry.Avogadro2.flatpakref"><span>Download Flatpak</span></a>
-++++
-<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_cmake/master/Avogadro2.AppImage.zip"><span>Download Nightly AppImage</span></a>
-<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="build.html"><span>Build from source</span></a>
+::::
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+
+:::{button-link} {{appurl}}
+:color: primary
+:outline:
+Download AppImage
 :::
 
-:::{card} 
-:text-align: center
-:class-header: sd-font-weight-bold sd-bg-light sd-text-danger
-{fab}`freebsd;fa-2x` FreeBSD
-^^^
-<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-outline-primary reference external" href="https://www.freshports.org/science/avogadro2/"><span>`pkg install avogadro2`</span></a>
+:::{button-link} https://flathub.org/apps/org.openchemistry.Avogadro2
+:color: primary
+:outline:
+Download Flatpak
 :::
+
+:::{button-link} https://repology.org/project/avogadro2/versions
+:color: primary
+:outline:
+Check your distro's repositories
+:::
+::::
+
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+
+:::{button-link} https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_cmake/master/Avogadro2.AppImage.zip
+:color: secondary
+:outline:
+Nightly AppImage
+:::
+::::
+
+
+% BSD row
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+:class-card: sd-font-weight-bold sd-bg-light
+{fab}`freebsd;fa-2x` FreeBSD
+::::
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+
+:::{button-link} https://www.freshports.org/science/avogadro2/
+:color: primary
+:outline:
+`pkg install avogadro2`
+:::
+::::
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+% Empty
+::::
+
+
+::::::
+
 
 ```{toctree}
 ---

--- a/source/install/index.md
+++ b/source/install/index.md
@@ -6,8 +6,9 @@ Most users will want to use the current official release ({{release}}).
 
 If you have problems using the current release or want to use the latest features, try out one of the **"nightly" builds** created every night from the current source code, which contains all improvements and bug fixes since the last release.
 
-We're open-source, so if you would like to compile Avogadro yourself from the code, you can – see [Building Source Code](install-build).
+We're open-source, so if you would like to compile Avogadro yourself from the code, you can -- see [Building Source Code](install-build) for more on how.
 
+<release:Darwin-arm64.dmg>
 
 ::::::{grid} 3
 :gutter: 0
@@ -21,7 +22,7 @@ We're open-source, so if you would like to compile Avogadro yourself from the co
 ::::{grid-item-card}
 :text-align: center
 :shadow: none
-:class-card: sd-font-weight-bold sd-bg-light
+:class-card: sd-font-weight-bold sd-bg-light sd-text-dark
 Current Release ({{release}})
 ::::
 
@@ -29,7 +30,7 @@ Current Release ({{release}})
 ::::{grid-item-card}
 :text-align: center
 :shadow: none
-:class-card: sd-font-weight-bold sd-bg-light
+:class-card: sd-font-weight-bold sd-bg-light sd-text-dark
 Nightly Build
 ::::
 
@@ -38,8 +39,10 @@ Nightly Build
 ::::{grid-item-card}
 :text-align: center
 :shadow: none
-:class-card: sd-font-weight-bold sd-bg-light
-{fab}`apple;fa-2x` macOS
+:class-card: sd-font-weight-bold sd-bg-light sd-text-dark
+{fab}`apple;fa-2x`
+
+macOS
 ::::
 
 
@@ -47,10 +50,18 @@ Nightly Build
 :text-align: center
 :shadow: none
 
+%:::{button-link} {{ 'https://github.com/OpenChemistry/avogadrolibs/releases/download/{}/Avogadro2-{}-Darwin-arm64.dmg'.format(release) }}
+:::{button-link} {{macarmurl}}
+:ref-type: myst
+:color: primary
+:outline:
+Download DMG (Apple Silicon)
+:::
+
 :::{button-link} {{macurl}}
 :color: primary
 :outline:
-Download DMG
+Download DMG (Intel)
 :::
 ::::
 
@@ -62,7 +73,7 @@ Download DMG
 :::{button-link} https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_cmake/master/macOS.dmg.zip
 :color: secondary
 :outline:
-Download Nightly Build
+Download Nightly Build (Intel)
 :::
 ::::
 
@@ -71,8 +82,10 @@ Download Nightly Build
 ::::{grid-item-card}
 :text-align: center
 :shadow: none
-:class-card: sd-font-weight-bold sd-bg-light
-{fab}`windows;fa-2x` Windows
+:class-card: sd-font-weight-bold sd-bg-light sd-text-dark
+{fab}`windows;fa-2x`
+
+Windows
 ::::
 
 
@@ -104,8 +117,10 @@ Download Nightly Build
 ::::{grid-item-card}
 :text-align: center
 :shadow: none
-:class-card: sd-font-weight-bold sd-bg-light
-{fab}`linux;fa-2x` Linux
+:class-card: sd-font-weight-bold sd-bg-light sd-text-dark
+{fab}`linux;fa-2x`
+
+Linux
 ::::
 
 ::::{grid-item-card}
@@ -148,8 +163,10 @@ Nightly AppImage
 ::::{grid-item-card}
 :text-align: center
 :shadow: none
-:class-card: sd-font-weight-bold sd-bg-light
-{fab}`freebsd;fa-2x` FreeBSD
+:class-card: sd-font-weight-bold sd-bg-light sd-text-dark
+{fab}`freebsd;fa-2x`
+
+FreeBSD
 ::::
 
 ::::{grid-item-card}
@@ -167,6 +184,39 @@ Nightly AppImage
 :text-align: center
 :shadow: none
 % Empty
+::::
+
+
+% Source code row
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+:class-card: sd-font-weight-bold sd-bg-light sd-text-dark
+{fas}`code;fa-2x`
+
+Source Code
+::::
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+
+:::{button-link} {{sourceurl}}
+:color: primary
+:outline:
+Download .zip
+:::
+::::
+
+::::{grid-item-card}
+:text-align: center
+:shadow: none
+
+:::{button-link} https://github.com/OpenChemistry/avogadrolibs
+:color: secondary
+:outline:
+Go to GitHub {fab}`github;fa-1x`
+:::
 ::::
 
 


### PR DESCRIPTION
I would also be keen to get thoughts on this reorganized downloads grid.

I tried to make it clearer which buttons are links to stable releases and which are to the nightly versions by making it two columns, with the purple for the nightly buttons.

I also tried to explain what a nightly build actually *is*, as that is a common question, though I'm not sure I really succeeded there.

Before:
![image](https://github.com/user-attachments/assets/d65cfac6-ec94-45ff-aafd-d4e75b13f397)
![image](https://github.com/user-attachments/assets/1ae12ccc-9b1c-494f-8bbd-86ad7a7feb61)


After:
![image](https://github.com/user-attachments/assets/00ba980f-162f-495d-9bd7-e2ec3b14c902)
![image](https://github.com/user-attachments/assets/03d4174a-50ec-47ef-9e56-57c8aca342b1)
![image](https://github.com/user-attachments/assets/a1556f11-206a-41f6-a445-9d46be0e8585)
