### PR TITLE
Restore standard Windows nightly build

### DIFF
--- a/source/install/index.md
+++ b/source/install/index.md
@@ -118,7 +118,7 @@ Download Installer
 :text-align: center
 :shadow: none
 
-:::{button-link} https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_windows/master/Win64-signed.exe.zip
+:::{button-link} https://nightly.link/OpenChemistry/avogadrolibs/workflows/build_cmake/master/Win64.exe.zip
 :color: secondary
 :outline:
 Download Nightly Build


### PR DESCRIPTION
We can't sign nightly builds, so go back to the previous build action